### PR TITLE
feat: add exit handlers

### DIFF
--- a/lib/common.sh
+++ b/lib/common.sh
@@ -41,3 +41,10 @@ check_dependencies() {
   fi
 }
 
+exit_panel() {
+  clear
+  echo "[DevPanel] Berhasil memberhentikan layanan."
+  echo "[DevPanel] Sampai jumpa kembali dilain waktu!"
+  exit 0
+}
+

--- a/lib/menu.sh
+++ b/lib/menu.sh
@@ -16,7 +16,7 @@ main_menu() {
       0 "Keluar" \
       3>&1 1>&2 2>&3)
 
-    [ $? -ne 0 ] && exit
+    [ $? -ne 0 ] && exit_panel
 
     case $MAIN_CHOICE in
       1) manage_services ;;
@@ -28,7 +28,7 @@ main_menu() {
       7) show_system_info ;;
       8) quick_actions ;;
       9) reset_all ;;
-      0) clear; echo "Terima kasih telah menggunakan Dev Panel!"; exit 0 ;;
+      0) exit_panel ;;
     esac
   done
 }

--- a/run.sh
+++ b/run.sh
@@ -10,5 +10,7 @@ source "$SCRIPT_DIR/lib/databases.sh"
 source "$SCRIPT_DIR/lib/system.sh"
 source "$SCRIPT_DIR/lib/menu.sh"
 
+trap exit_panel INT
+
 check_dependencies
 main_menu


### PR DESCRIPTION
## Summary
- handle SIGINT to exit panel gracefully
- display farewell message when canceling from main menu

## Testing
- `bash -n run.sh lib/common.sh lib/menu.sh`
- `apt-get update` *(fails: The repository 'http://security.ubuntu.com/ubuntu noble-security InRelease' is not signed)*

------
https://chatgpt.com/codex/tasks/task_e_68c77e325eb883289f1f27e0f1ff9f68